### PR TITLE
Copy tweaks 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -46,13 +46,11 @@ const getAbsentMessage = (
   commitSha: string,
   addChangesetUrl: string,
   releasePlan: ReleasePlan | null
-) => `###  💥  No Changeset
+) => `###  ⚠️  No Changeset found
 
 Latest commit: ${commitSha}
 
-Merging this PR will not cause any packages to be released. If these changes should not cause updates to packages in this repo, this is fine 🙂
-
-**If these changes should be published to npm, you need to add a changeset.**
+Merging this PR will not cause a version bump for any packages. If these changes should not result in a new version, you're good to go. **If these changes should result in a version bump, you need to add a changeset.**
 
 ${getReleasePlanMessage(releasePlan)}
 
@@ -66,11 +64,11 @@ const getApproveMessage = (
   commitSha: string,
   addChangesetUrl: string,
   releasePlan: ReleasePlan | null
-) => `###  🦋  Changeset is good to go
+) => `###  🦋  Changeset detected
 
 Latest commit: ${commitSha}
 
-**We got this.**
+**The changes in this PR will be included in the next version bump.**
 
 ${getReleasePlanMessage(releasePlan)}
 


### PR DESCRIPTION
Hey y'all 👋 After adopting changesets for our design system, we had some feedback around the clarity of the messages left on PRs by the GitHub bot. I wanted to open a PR to kick off a discussion around improving these messages to be a bit more clear. 

I've made a few tweaks that I think could help:

1. Changed `💥  No Changeset` to `⚠️  No Changeset found` to more clearly indicate that this is a warning, not an error 
2. Revised "Merging this PR will not cause any packages to be released." to "Merging this PR will not cause a version bump for any packages."  to be explicit that merging these PRs will _never_ result in an automatic package release. 
3. Changed `Changeset is good to go` to `Changeset detected` to be more explicit about what the bot is looking for 
4. Replaced the simple "We got this." phrase with something more descriptive: "The changes in this PR will be included in the next version bump."

Let me know if you have any thoughts or suggestions!