### PR TITLE
Feature: Comment on released PRs and issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@
 
 ## Install the bot at https://github.com/apps/changeset-bot
 
-
-
 This bot will comment on PRs saying that either a user might need to add a changeset(note that PRs changing things like documentation generally don't need a changeset)or say that the PR is good and already has a changeset.
+
+It wil also comment on released Pull Requests/Issues.
 
 <img width="1552" alt="screenshot of changeset bot message from https://github.com/mitchellhamilton/manypkg/pull/18 before a changeset was added" src="https://user-images.githubusercontent.com/11481355/66183943-dc418680-e6bd-11e9-998d-e43f90a974bd.png">
 
 <img width="1552" alt="screenshot of the changeset bot message from https://github.com/mitchellhamilton/manypkg/pull/18 showing the changeset good to go message" src="https://user-images.githubusercontent.com/11481355/66184229-cf716280-e6be-11e9-950e-0f64a31dbf15.png">
-
 
 Sometimes, a contributor won't add a changeset to a PR but you might want to merge in the PR without having to wait on them to add it. To address this, this bot adds a link with the filename pre-filled to add a changeset so all you have to do is write the changeset and click commit.
 
@@ -27,16 +26,16 @@ When writing the changeset, it should look something like this with the packages
 
 ```markdown
 ---
-'@changesets/cli': major
-'@changesets/read': minor
+"@changesets/cli": major
+"@changesets/read": minor
 ---
 
 A very helpful description of the changes
 ```
+
 ---
 
 The information below is for contributing to the bot.
-
 
 ## Setup
 

--- a/app.yml
+++ b/app.yml
@@ -82,7 +82,7 @@ default_permissions:
 
   # Pull requests and related comments, assignees, labels, milestones, and merges.
   # https://developer.github.com/v3/apps/permissions/#permission-on-pull-requests
-   pull_requests: write
+  pull_requests: write
 
   # Manage the post-receive hooks for a repository.
   # https://developer.github.com/v3/apps/permissions/#permission-on-repository-hooks

--- a/index.ts
+++ b/index.ts
@@ -186,7 +186,7 @@ export default (app: Application) => {
         .listTags({
           ...repo,
           per_page: 100,
-          tagPage,
+          page: tagPage,
         })
         .then(({ data }) => {
           const tag = data.find((el) => el.name === tag_name);
@@ -196,7 +196,8 @@ export default (app: Application) => {
             tagCommitSha = tag.commit.sha;
           }
           tagPage += 1;
-        });
+        })
+        .catch((err) => console.warn(err));
     }
 
     /* 3 */

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/micromatch": "^4.0.1",
     "@types/node-fetch": "^2.5.5",
     "human-id": "^1.0.2",
+    "issue-parser": "^6.0.0",
     "js-yaml": "^3.14.0",
     "markdown-table": "^2.0.0",
     "node-fetch": "^2.6.1",
@@ -27,6 +28,7 @@
     "typescript": "^4.0.3"
   },
   "devDependencies": {
+    "@types/issue-parser": "^3.0.0",
     "jest": "^24.1.0",
     "nock": "^10.0.0",
     "outdent": "^0.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,6 +1046,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/issue-parser@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/issue-parser/-/issue-parser-3.0.0.tgz#154dcdea73c3447b0e30d8ab3dfe2661a531884b"
+  integrity sha512-wDi9vfrRlosge6GIjC8ToxeiyG7qYSNWRwZIxav0uPIn7LfGdo6RsKztAAFReXipFM5vDIYGgBiAEXcZ/EIniw==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -3291,6 +3296,17 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+issue-parser@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/issue-parser/-/issue-parser-6.0.0.tgz#b1edd06315d4f2044a9755daf85fdafde9b4014a"
+  integrity sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==
+  dependencies:
+    lodash.capitalize "^4.2.1"
+    lodash.escaperegexp "^4.1.2"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.uniqby "^4.7.0"
+
 istanbul-lib-coverage@^2.0.2, istanbul-lib-coverage@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
@@ -3954,10 +3970,20 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.capitalize@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
+  integrity sha1-+CbJtOKoUR2E46yinbBeGk87cqk=
+
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
   integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.escaperegexp@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+  integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
 
 lodash.flatten@^4.4.0:
   version "4.4.0"
@@ -4004,12 +4030,12 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.5:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+lodash.uniqby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
+  integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@^4.17.19:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.19, lodash@^4.17.5:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
Closes [#511](https://github.com/atlassian/changesets/issues/511)

This PR adds a new feature that allows the bot to comment on PRs and issues that have been released.

My work is inspired by what [semantic-release/github](https://github.com/semantic-release/github) has done.

Here is a schema showing the workflow to retrieve the released Pull Requests and Issues.

<p align="center">
<img src="https://user-images.githubusercontent.com/32459935/112027109-2b3fdd80-8b37-11eb-82ac-be6b05eadd2d.png" width="600" />
</p>

## Comment message

Here is a comment message example:

###  🦋  This work has been released in release version: v0.4.3

Release link: https://github.com/backstage/backstage/releases/tag/v0.4.3

Note that the message is the same for PRs and issues.   
It might be interesting to have two different messages for the different cases?

## Example

I also created a [codesanbox](https://codesandbox.io/s/winter-bird-pwn6v?file=/src/index.js) where you can see the logic  to get the issues and pull-requests associated to a release more easily. 
**NOTE**: In the codesanbox, considering that the code does not run at the time the release is created, we will get more recent commits. This will not happen in the dropbot project.

## Notes

I couldn't find a better way to find the tag associated to the release than looking through the tags until I found the tag corresponding to the release. Knowing that the service is paginated, I added the fetch logic with the `while`.
