### PR TITLE
feat: check for changed files not only in root folder

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -123,8 +123,8 @@ const hasChangesetBeenAdded = (
     files.data.some(
       (file) =>
         file.status === "added" &&
-        /^\.changeset\/.+\.md$/.test(file.filename) &&
-        file.filename !== ".changeset/README.md"
+        /\.changeset\/.+\.md$/.test(file.filename) &&
+        !file.filename.endsWith(".changeset/README.md")
     )
   );
 


### PR DESCRIPTION
Just a tiny change, but it could help the 🤖 to provide its helpful comments even if the changesets aren’t located within the root folder.

ref #60 