### PR TITLE
Rename changesets branch to `main`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -65,7 +65,7 @@ Merging this PR will not cause a version bump for any packages. If these changes
 
 ${getReleasePlanMessage(releasePlan)}
 
-[Click here to learn what changesets are, and how to add one](https://github.com/changesets/changesets/blob/master/docs/adding-a-changeset.md).
+[Click here to learn what changesets are, and how to add one](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
 
 [Click here if you're a maintainer who wants to add a changeset to this PR](${addChangesetUrl})
 
@@ -83,7 +83,7 @@ Latest commit: ${commitSha}
 
 ${getReleasePlanMessage(releasePlan)}
 
-Not sure what this means? [Click here  to learn what changesets are](https://github.com/changesets/changesets/blob/master/docs/adding-a-changeset.md).
+Not sure what this means? [Click here  to learn what changesets are](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
 
 [Click here if you're a maintainer who wants to add another changeset to this PR](${addChangesetUrl})
 


### PR DESCRIPTION
I followed the link from the bot's message, and I noticed the redirection because the default branch of [`changesets/changesets`](https://github.com/changesets/changesets) has been renamed to `main`.

We can safely rename the branch used in the template from `master` to `main` to prevent those redirections.