### PR TITLE
fix: malformed addChangesetUrl

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -200,7 +200,7 @@ export default (app: Probot) => {
           context.payload.pull_request.head.repo.html_url
         }/new/${
           context.payload.pull_request.head.ref
-        }?filename=.changeset/${humanId({
+        }/.changeset?filename=${humanId({
           separator: "-",
           capitalize: false,
         })}.md&value=${getNewChangesetTemplate(


### PR DESCRIPTION
The URL generated by the bot is malformed and when trying to commit via github UI you get an error that the file cannot be written. This PR fixes the url

Before:
https://github.com/path/to/repo/new/branch?filename=.changeset/name.md&value=...

After:
https://github.com/path/to/repo/new/branch/.changeset?filename=name.md&value=...
