### PR TITLE
Correct CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @Andarist
-* @emmatown
+* @Andarist @emmatown


### PR DESCRIPTION
Hi @Andarist,
I noticed you added yourself to the `CODEOWNERS` file in PR #101. 
However, you weren’t requested as a reviewer in PR #102.

It looks like the issue may be due to having multiple entries with the same match pattern (`*`). 
In `CODEOWNERS`, only one rule applies per pattern, so subsequent duplicates are ignored.

Combining all owners under a single `*` entry should resolve the problem.

Reference: 
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection