### PR TITLE
fix: vercel deploy failing due to ts moduleResolution error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Setup dependencies
         uses: ./.github/actions/ci-setup
 
+      - name: Run next build
+        run: yarn next build
+
       - name: Run test
         run: yarn test
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "incremental": false,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "ignoreDeprecations": "6.0"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Maybe Vercel deploy is failing due the following `next build` error (reproducible locally):

```text
Type error: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
  Visit https://aka.ms/ts6 for migration information.
```

As a quick fix I disabled `ts@6` deprecation warning and added a `yarn next build` to the test ci job to avoid possible regression in the future.

I don't have access to the deploy log so this is a blind fix 😅

---

As wrote on Discord I can update the tsconfig later to avoid suppressing the warnings. 
This PR is just intended as an hotfix