### PR TITLE
fix: vercel deploy failing due to ts moduleResolution error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Setup dependencies
         uses: ./.github/actions/ci-setup
 
+      - name: Run next build
+        run: yarn next build
+
       - name: Run test
         run: yarn test
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "typescript": "^6.0.2"
   },
   "devDependencies": {
-    "@tsconfig/next": "^2.0.6",
     "knip": "^6.11.0",
     "msw": "^2.12.14",
     "oxfmt": "^0.42.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,20 @@
 {
-  "extends": "@tsconfig/next/tsconfig.json",
   "compilerOptions": {
-    "allowJs": false,
-    "tsBuildInfoFile": "node_modules/.cache/.tsbuildinfo",
-    "forceConsistentCasingInFileNames": true,
+    "target": "esnext",
+    "module": "commonjs",
+    "noEmit": true,
     "strict": true,
-    "moduleResolution": "bundler"
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "incremental": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "ignoreDeprecations": "6.0"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,11 +1149,6 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@tsconfig/next@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@tsconfig/next/-/next-2.0.6.tgz#e0ba358eed17da684c6e013a14e1c53fc6cd4822"
-  integrity sha512-C6eZoNyAMKv2UvzDZqcp8zXPviu6W4Ev1KUbqfmaMSZuq+tmbtTWaqxTif/yaui8WCEcRlQrHC8q9tNzBclHOw==
-
 "@tybys/wasm-util@^0.10.1":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"


### PR DESCRIPTION
https://github.com/changesets/bot/pull/106 didn't solved the issue:

Build errors are different now

<img width="1289" height="243" alt="image" src="https://github.com/user-attachments/assets/728aae6e-2e3b-414f-a366-846d44fc53dc" />

```text
We detected TypeScript in your project and reconfigured your tsconfig.json file for you. Strict-mode is set to false by default.

The following suggested values were added to your tsconfig.json. These values can be changed to fit your project's needs:

        - target was set to es5

The following mandatory changes were made to your tsconfig.json:

        - moduleResolution was set to node (to match webpack resolution)

Failed to compile.
```

Since `next` is explicitly forcing the use of `node10`, adjusting the `tsconfig` won’t resolve the issue.

As suggested in #105, a short-term approach would be to temporarily suppress the deprecation warning to restore deployment stability. 

~~Once that’s in place, we can plan a proper upgrade of `next` and then remove the suppression to address the warning correctly.~~ Outdated, see https://github.com/changesets/bot/pull/109

